### PR TITLE
vxfw(List): make Offset public

### DIFF
--- a/vxfw/list/list.go
+++ b/vxfw/list/list.go
@@ -86,6 +86,11 @@ func (d *Dynamic) Cursor() uint {
 	return d.cursor
 }
 
+// Offset returns the rendered offset of the list
+func (d *Dynamic) Offset() uint {
+	return d.scroll.offset
+}
+
 func (d *Dynamic) HandleEvent(ev vaxis.Event, ph vxfw.EventPhase) (vxfw.Command, error) {
 	if d.DisableEventHandlers {
 		return nil, nil


### PR DESCRIPTION
Add the ability to retrieve the rendered offset of the list. It enables the ability to get an element as rendered in the list of the current view of the user.