### PR TITLE
Add support for pixel-precise mouse reporting through SGR Pixels

### DIFF
--- a/event.go
+++ b/event.go
@@ -21,6 +21,7 @@ type (
 	textAreaPix            struct{}
 	textAreaChar           struct{}
 	inBandResizeEvents     struct{}
+	capabilitySgrPixels    struct{}
 	appID                  string
 	terminalID             string
 )

--- a/sequences.go
+++ b/sequences.go
@@ -87,6 +87,7 @@ const (
 	mouseAllEvents     = 1003
 	mouseFocusEvents   = 1004
 	mouseSGR           = 1006
+	mouseSGRPixels     = 1016
 	alternateScreen    = 1049
 	bracketedPaste     = 2004
 	synchronizedUpdate = 2026


### PR DESCRIPTION
This PR allows for reporting of pixel-precise movement of mouse. Mouse Event now has `XPixel` and `YPixel` along with `Col` and `Row`. 

This feature is opt-in only by setting `EnableSGRPixels` to `true` in options.

Let me know if you need any changes. Thanks for this OK-dank library :p