### PR TITLE
Fixed Resume not respecting NoSignals

### DIFF
--- a/vaxis.go
+++ b/vaxis.go
@@ -1682,6 +1682,10 @@ func (vx *Vaxis) CanExplicitWidth() bool {
 	return vx.caps.explicitWidth
 }
 
+func (vx *Vaxis) CanInBandResize() bool {
+  return vx.caps.inBandResize
+}
+
 func (vx *Vaxis) nextGraphicID() uint64 {
 	vx.graphicsIDNext += 1
 	return vx.graphicsIDNext

--- a/vaxis.go
+++ b/vaxis.go
@@ -194,9 +194,8 @@ func New(opts Options) (*Vaxis, error) {
 		vx.disableMouse = true
 	}
 
-	if opts.NoSignals {
-		vx.noSignals = true
-	}
+	vx.noSignals = opts.NoSignals
+
 
 	var tgts []*os.File
 

--- a/vaxis.go
+++ b/vaxis.go
@@ -142,6 +142,8 @@ type Vaxis struct {
 
 	mu     sync.Mutex
 	resize int32
+
+	noSignals bool
 }
 
 // New creates a new [Vaxis] instance. Calling New will query the underlying
@@ -190,6 +192,10 @@ func New(opts Options) (*Vaxis, error) {
 
 	if opts.DisableMouse {
 		vx.disableMouse = true
+	}
+
+	if opts.NoSignals {
+		vx.noSignals = true
 	}
 
 	var tgts []*os.File
@@ -345,7 +351,7 @@ outer:
 
 	vx.enterAltScreen()
 	vx.enableModes()
-	if !opts.NoSignals {
+	if !vx.noSignals {
 		vx.setupSignals()
 	}
 	vx.applyQuirks()
@@ -1465,7 +1471,10 @@ func (vx *Vaxis) Resume() error {
 
 	vx.enterAltScreen()
 	vx.enableModes()
-	vx.setupSignals()
+
+	if !vx.noSignals {
+		vx.setupSignals()
+	}
 	atomicStore(&vx.resize, true)
 	return nil
 }


### PR DESCRIPTION
along with this I exposed the inBandResize cap. My reasoning for it is so a user with NoSignals can decide whether to manually setup a SIGWINCH signal handler.

I am a bit confused on the Windows side though. Since `winch()` is called in setupSignals; with NoSignals, how would win size change be reported?