### PR TITLE
color: add terminal color constants

### DIFF
--- a/color.go
+++ b/color.go
@@ -11,6 +11,28 @@ const (
 	rgb     Color = 1 << 25
 )
 
+const (
+	// Indexed terminal color constants
+	ColorBlack Color = iota | indexed
+	ColorMaroon
+	ColorGreen
+	ColorOlive
+	ColorNavy
+	ColorPurple
+	ColorTeal
+	ColorSilver
+	ColorGray
+	ColorRed
+	ColorLime
+	ColorYellow
+	ColorBlue
+	ColorFuschia
+	ColorAqua
+	ColorWhite
+
+	ColorDefault Color = 0
+)
+
 // Params returns the TParm parameters for the color, or an empty slice if the
 // color is the default color
 func (c Color) Params() []uint8 {


### PR DESCRIPTION
When a vaxis program uses terminal colors for elements, using `vaxis.IndexColor(2)` among other colors can get unreadable very fast, especially if its used very frequently, requiring the programmer to explain the color. This PR addresses this problem by making constants such as `ColorGreen`.