### PR TITLE
vxfw(List): allow scrolling to the top

### DIFF
--- a/vxfw/list/list.go
+++ b/vxfw/list/list.go
@@ -102,11 +102,8 @@ func (d *Dynamic) HandleEvent(ev vaxis.Event, ph vxfw.EventPhase) (vxfw.Command,
 			d.scroll.pending += 3
 			return vxfw.ConsumeAndRedraw(), nil
 		case vaxis.MouseWheelUp:
-			if d.scroll.offset > 0 && d.scroll.top > 0 {
-				// We can only scroll up if we are at the top
-				d.scroll.pending -= 3
-				return vxfw.ConsumeAndRedraw(), nil
-			}
+			d.scroll.pending -= 3
+			return vxfw.ConsumeAndRedraw(), nil
 		}
 	}
 	return nil, nil


### PR DESCRIPTION
This makes scrolling more expected, as without this change, in certain applications, scrolling up is simply not allowed; and in the example, scrolling up only goes one column up.