### PR TITLE
vxfw: add fill character and fill cell methods for surface

### DIFF
--- a/vxfw/button/button.go
+++ b/vxfw/button/button.go
@@ -123,7 +123,7 @@ func (b *Button) Draw(ctx vxfw.DrawContext) (vxfw.Surface, error) {
 	// Rewrite the widget of this surface. We don't really care about the
 	// Center widget anyways, it's just for layout
 	s.Widget = b
-	s.Fill(style)
+	s.FillStyle(style)
 	return s, nil
 }
 

--- a/vxfw/text/text.go
+++ b/vxfw/text/text.go
@@ -42,7 +42,7 @@ func (t *Text) Draw(ctx vxfw.DrawContext) (vxfw.Surface, error) {
 
 	size := t.findContainerSize(ctx)
 	s := vxfw.NewSurface(size.Width, size.Height, t)
-	s.Fill(t.Style)
+	s.FillStyle(t.Style)
 
 	scanner := bufio.NewScanner(strings.NewReader(t.Content))
 	var row uint16
@@ -90,7 +90,7 @@ func (t *Text) Draw(ctx vxfw.DrawContext) (vxfw.Surface, error) {
 func (t *Text) drawSoftwrap(ctx vxfw.DrawContext) (vxfw.Surface, error) {
 	size := t.findContainerSize(ctx)
 	s := vxfw.NewSurface(size.Width, size.Height, t)
-	s.Fill(t.Style)
+	s.FillStyle(t.Style)
 
 	scanner := NewSoftwrapScanner(t.Content, ctx.Max.Width)
 	var row uint16

--- a/vxfw/vxfw.go
+++ b/vxfw/vxfw.go
@@ -134,9 +134,24 @@ func (s *Surface) WriteCell(col uint16, row uint16, cell vaxis.Cell) {
 	s.Buffer[i] = cell
 }
 
-func (s *Surface) Fill(style vaxis.Style) {
+// FillStyle sets style on all cells in s
+func (s *Surface) FillStyle(style vaxis.Style) {
 	for i := range s.Buffer {
 		s.Buffer[i].Style = style
+	}
+}
+
+// FillCharacter writes ch to all cells in s
+func (s *Surface) FillCharacter(ch vaxis.Character) {
+	for i := range s.Buffer {
+		s.Buffer[i].Character = ch
+	}
+}
+
+// Fill writes cell to all cells in s
+func (s *Surface) Fill(cell vaxis.Cell) {
+	for i := range s.Buffer {
+		s.Buffer[i] = cell
 	}
 }
 


### PR DESCRIPTION
This patch changes `surface.Fill` to take a `vaxis.Cell`, and adds `surface.FillStyle` and `surface.FillCharacter`.

Technically it's a breaking change, so let me know if you'd rather leave the original `Fill` alone and instead introduce `FillCharacter` and `FillCell`.