### PR TITLE
vxfw: add constraint helpers for DrawContext

### DIFF
--- a/_examples/vxfw/button/button.go
+++ b/_examples/vxfw/button/button.go
@@ -34,13 +34,10 @@ func (a *App) HandleEvent(ev vaxis.Event, phase vxfw.EventPhase) (vxfw.Command, 
 }
 
 func (a *App) Draw(ctx vxfw.DrawContext) (vxfw.Surface, error) {
-	chCtx := vxfw.DrawContext{
-		Max: vxfw.Size{
-			Width:  ctx.Max.Width / 2,
-			Height: ctx.Max.Height / 2,
-		},
-		Characters: ctx.Characters,
-	}
+	chCtx := ctx.WithMax(vxfw.Size{
+		Width:  ctx.Max.Width / 2,
+		Height: ctx.Max.Height / 2,
+	})
 	s, err := a.b.Draw(chCtx)
 	if err != nil {
 		return vxfw.Surface{}, err

--- a/_examples/vxfw/input/main.go
+++ b/_examples/vxfw/input/main.go
@@ -32,10 +32,7 @@ func (a *App) HandleEvent(ev vaxis.Event, phase vxfw.EventPhase) (vxfw.Command, 
 }
 
 func (a *App) Draw(ctx vxfw.DrawContext) (vxfw.Surface, error) {
-	chCtx := vxfw.DrawContext{
-		Max:        vxfw.Size{Width: 24, Height: math.MaxUint16},
-		Characters: ctx.Characters,
-	}
+	chCtx := ctx.WithMax(vxfw.Size{Width: 24, Height: math.MaxUint16})
 	s, err := a.input.Draw(chCtx)
 	if err != nil {
 		return vxfw.Surface{}, err

--- a/_examples/vxfw/main.go
+++ b/_examples/vxfw/main.go
@@ -56,10 +56,7 @@ func (a *App) HandleEvent(ev vaxis.Event, phase vxfw.EventPhase) (vxfw.Command, 
 }
 
 func (a *App) Draw(ctx vxfw.DrawContext) (vxfw.Surface, error) {
-	chCtx := vxfw.DrawContext{
-		Max:        vxfw.Size{Width: 24, Height: math.MaxUint16},
-		Characters: ctx.Characters,
-	}
+	chCtx := ctx.WitMax(vxfw.Size{Width: 24, Height: math.MaxUint16})
 	s, err := a.t.Draw(chCtx)
 	if err != nil {
 		return vxfw.Surface{}, err

--- a/_examples/vxfw/main.go
+++ b/_examples/vxfw/main.go
@@ -56,7 +56,7 @@ func (a *App) HandleEvent(ev vaxis.Event, phase vxfw.EventPhase) (vxfw.Command, 
 }
 
 func (a *App) Draw(ctx vxfw.DrawContext) (vxfw.Surface, error) {
-	chCtx := ctx.WitMax(vxfw.Size{Width: 24, Height: math.MaxUint16})
+	chCtx := ctx.WithMax(vxfw.Size{Width: 24, Height: math.MaxUint16})
 	s, err := a.t.Draw(chCtx)
 	if err != nil {
 		return vxfw.Surface{}, err

--- a/vxfw/center/center.go
+++ b/vxfw/center/center.go
@@ -18,11 +18,7 @@ func (c *Center) Draw(ctx vxfw.DrawContext) (vxfw.Surface, error) {
 	if ctx.Max.HasUnboundedHeight() || ctx.Max.HasUnboundedWidth() {
 		panic("Center must have bounded constraints")
 	}
-	chCtx := vxfw.DrawContext{
-		Max:        ctx.Max,
-		Characters: ctx.Characters,
-	}
-	chS, err := c.Child.Draw(chCtx)
+	chS, err := c.Child.Draw(ctx)
 	if err != nil {
 		return vxfw.Surface{}, nil
 	}

--- a/vxfw/list/list.go
+++ b/vxfw/list/list.go
@@ -168,13 +168,11 @@ func (d *Dynamic) Draw(ctx vxfw.DrawContext) (vxfw.Surface, error) {
 		i += 1
 
 		// Set up constraints
-		chCtx := vxfw.DrawContext{
-			Max: vxfw.Size{
-				Width:  ctx.Max.Width - uint16(colOffset),
-				Height: math.MaxUint16,
-			},
-			Characters: ctx.Characters,
-		}
+		chCtx := ctx.WithMax(vxfw.Size{
+			Width:  ctx.Max.Width - uint16(colOffset),
+			Height: math.MaxUint16,
+		})
+
 		// Draw the child
 		chS, err := ch.Draw(chCtx)
 		if err != nil {
@@ -302,13 +300,10 @@ func (d *Dynamic) insertChildren(ctx vxfw.DrawContext, p *vxfw.Surface, ah int) 
 	}
 
 	for ah > 0 {
-		chCtx := vxfw.DrawContext{
-			Max: vxfw.Size{
-				Width:  ctx.Max.Width - uint16(colOffset),
-				Height: math.MaxUint16,
-			},
-			Characters: ctx.Characters,
-		}
+		chCtx := ctx.WithMax(vxfw.Size{
+			Width:  ctx.Max.Width - uint16(colOffset),
+			Height: math.MaxUint16,
+		})
 		ch := d.Builder(d.scroll.top, d.cursor)
 		// Break if we don't have a widget, really this should never
 		// happen

--- a/vxfw/vxfw.go
+++ b/vxfw/vxfw.go
@@ -72,6 +72,25 @@ type DrawContext struct {
 	Characters func(string) []vaxis.Character
 }
 
+// WithConstraints returns a new DrawContext with the supplied min and max size
+// Use [DrawContext.WithMin] or [DrawContext.WithMax] to change one constraint
+func (ctx DrawContext) WithConstraints(min, max Size) DrawContext {
+	return DrawContext{
+		Min: min, Max: max,
+		Characters: ctx.Characters,
+	}
+}
+
+// WithMin returns a new DrawContext with the minimum size set to min
+func (ctx DrawContext) WithMin(min Size) DrawContext {
+	return ctx.WithConstraints(min, ctx.Max)
+}
+
+// WithMax returns a new DrawContext with the maximum size set to max
+func (ctx DrawContext) WithMax(max Size) DrawContext {
+	return ctx.WithConstraints(ctx.Min, max)
+}
+
 type Size struct {
 	Width  uint16
 	Height uint16


### PR DESCRIPTION
This patch introduces .WithConstraints(min, max Size), .WithMax(Size), and .WithMin(Size) to vxfw.DrawContext, as well as changing some usage within the codebase to use the new constraint helpers.