### PR TITLE
vxfw: implement layout.FlexLayout

### DIFF
--- a/_examples/vxfw/flex/main.go
+++ b/_examples/vxfw/flex/main.go
@@ -5,6 +5,7 @@ import (
 
 	"git.sr.ht/~rockorager/vaxis"
 	"git.sr.ht/~rockorager/vaxis/vxfw"
+	"git.sr.ht/~rockorager/vaxis/vxfw/center"
 	"git.sr.ht/~rockorager/vaxis/vxfw/richtext"
 	"git.sr.ht/~rockorager/vaxis/vxfw/text"
 	"git.sr.ht/~rockorager/vaxis/vxfw/vxlayout"
@@ -43,11 +44,18 @@ func (a *App) HandleEvent(ev vaxis.Event, phase vxfw.EventPhase) (vxfw.Command, 
 
 func (a *App) Draw(ctx vxfw.DrawContext) (vxfw.Surface, error) {
 	root := vxfw.NewSurface(ctx.Max.Width, ctx.Max.Height, a)
-	layout, err := a.layout.Draw(vxfw.DrawContext{
-		Min:        ctx.Min,
-		Max:        vxfw.Size{Width: ctx.Max.Width, Height: ctx.Max.Height - 1},
-		Characters: ctx.Characters,
-	})
+
+	// the example layout should be constrained to a smaller size in the cross dimension, since
+	// otherwise Center will take up everything.
+	layoutCtx := vxfw.DrawContext(ctx)
+	switch a.layout.Direction {
+	case vxlayout.FlexHorizontal:
+		layoutCtx.Max.Height = 1
+	case vxlayout.FlexVertical:
+		layoutCtx.Max.Width = 6
+		layoutCtx.Max.Height -= 1 // leave room for the hint
+	}
+	layout, err := a.layout.Draw(layoutCtx)
 	if err != nil {
 		return vxfw.Surface{}, err
 	}
@@ -72,9 +80,9 @@ func main() {
 		richtext.New([]vaxis.Segment{
 			{Text: "FIRST", Style: vaxis.Style{Background: vaxis.IndexColor(1)}},
 		}),
-		richtext.New([]vaxis.Segment{
+		&center.Center{Child: richtext.New([]vaxis.Segment{
 			{Text: "MIDDLE", Style: vaxis.Style{Background: vaxis.IndexColor(2)}},
-		}),
+		})},
 		richtext.New([]vaxis.Segment{
 			{Text: "LAST", Style: vaxis.Style{Background: vaxis.IndexColor(3)}},
 		}),

--- a/_examples/vxfw/flex/main.go
+++ b/_examples/vxfw/flex/main.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"log"
+
+	"git.sr.ht/~rockorager/vaxis"
+	"git.sr.ht/~rockorager/vaxis/vxfw"
+	"git.sr.ht/~rockorager/vaxis/vxfw/richtext"
+	"git.sr.ht/~rockorager/vaxis/vxfw/text"
+	"git.sr.ht/~rockorager/vaxis/vxfw/vxlayout"
+)
+
+type App struct {
+	help   vxfw.Widget
+	layout *vxlayout.FlexLayout
+}
+
+func (a *App) CaptureEvent(ev vaxis.Event) (vxfw.Command, error) {
+	switch ev := ev.(type) {
+	case vaxis.Key:
+		if ev.Matches('c', vaxis.ModCtrl) {
+			return vxfw.QuitCmd{}, nil
+		}
+		if ev.Matches('l') || ev.Matches('L') {
+			a.swapLayout()
+			return vxfw.ConsumeAndRedraw(), nil
+		}
+	}
+	return nil, nil
+}
+
+func (a *App) swapLayout() {
+	if a.layout.Direction == vxlayout.FlexVertical {
+		a.layout.Direction = vxlayout.FlexHorizontal
+	} else {
+		a.layout.Direction = vxlayout.FlexVertical
+	}
+}
+
+func (a *App) HandleEvent(ev vaxis.Event, phase vxfw.EventPhase) (vxfw.Command, error) {
+	return nil, nil
+}
+
+func (a *App) Draw(ctx vxfw.DrawContext) (vxfw.Surface, error) {
+	root := vxfw.NewSurface(ctx.Max.Width, ctx.Max.Height, a)
+	layout, err := a.layout.Draw(vxfw.DrawContext{
+		Min:        ctx.Min,
+		Max:        vxfw.Size{Width: ctx.Max.Width, Height: ctx.Max.Height - 1},
+		Characters: ctx.Characters,
+	})
+	if err != nil {
+		return vxfw.Surface{}, err
+	}
+
+	help, err := a.help.Draw(vxfw.DrawContext{
+		Max:        vxfw.Size{Width: ctx.Max.Width, Height: 1},
+		Characters: ctx.Characters,
+	})
+
+	root.AddChild(0, 0, help)
+	root.AddChild(0, 1, layout)
+	return root, nil
+}
+
+func main() {
+	app, err := vxfw.NewApp(vaxis.Options{})
+	if err != nil {
+		log.Fatalf("Couldn't create a new app: %v", err)
+	}
+
+	widgets := []vxfw.Widget{
+		richtext.New([]vaxis.Segment{
+			{Text: "FIRST", Style: vaxis.Style{Background: vaxis.IndexColor(1)}},
+		}),
+		richtext.New([]vaxis.Segment{
+			{Text: "MIDDLE", Style: vaxis.Style{Background: vaxis.IndexColor(2)}},
+		}),
+		richtext.New([]vaxis.Segment{
+			{Text: "LAST", Style: vaxis.Style{Background: vaxis.IndexColor(3)}},
+		}),
+	}
+
+	root := &App{
+		help: text.New("Ctrl+C to quit, L (or l) to switch layouts."),
+		layout: &vxlayout.FlexLayout{
+			Children: []*vxlayout.FlexItem{
+				{Widget: widgets[0], Flex: 0},
+				{Widget: widgets[1], Flex: 1},
+				{Widget: widgets[2], Flex: 0},
+			},
+			Direction: vxlayout.FlexHorizontal,
+		},
+	}
+
+	app.Run(root)
+}

--- a/vxfw/center/center.go
+++ b/vxfw/center/center.go
@@ -18,14 +18,18 @@ func (c *Center) Draw(ctx vxfw.DrawContext) (vxfw.Surface, error) {
 	if ctx.Max.HasUnboundedHeight() || ctx.Max.HasUnboundedWidth() {
 		panic("Center must have bounded constraints")
 	}
-	chS, err := c.Child.Draw(ctx)
+
+	// Draw the child with no minimum so we can center it with any remaining space
+	chS, err := c.Child.Draw(ctx.WithMin(vxfw.Size{}))
 	if err != nil {
 		return vxfw.Surface{}, nil
 	}
+
 	// Create the surface for center
 	s := vxfw.NewSurface(ctx.Max.Width, ctx.Max.Height, c)
 	offX := (ctx.Max.Width - chS.Size.Width) / 2
 	offY := (ctx.Max.Height - chS.Size.Height) / 2
+
 	s.AddChild(int(offX), int(offY), chS)
 	return s, err
 }

--- a/vxfw/vxlayout/flex.go
+++ b/vxfw/vxlayout/flex.go
@@ -1,0 +1,177 @@
+package vxlayout
+
+import (
+	"git.sr.ht/~rockorager/vaxis"
+	"git.sr.ht/~rockorager/vaxis/vxfw"
+)
+
+type FlexDirection int
+
+const (
+	FlexHorizontal FlexDirection = iota
+	FlexVertical
+)
+
+// FlexItem is a [vxfw.Widget] used in a [FlexLayout]
+type FlexItem struct {
+	vxfw.Widget
+
+	// Flex determines how much space the widget takes in the layout.
+	// Flex of 0 means the widget will be its inherent size.
+	// Remaining space is divided proportionally to all FlexItems with Flex > 0
+	Flex uint8
+}
+
+// flexContext takes a [vxfw.DrawContext] and a size and returns a new DrawContext that
+// clamps the main axis to size
+func (f FlexDirection) flexContext(ctx vxfw.DrawContext, size uint16) vxfw.DrawContext {
+	out := vxfw.DrawContext(ctx)
+	switch f {
+	case FlexHorizontal:
+		out.Min.Width = size
+		out.Max.Width = size
+	case FlexVertical:
+		out.Min.Height = size
+		out.Max.Height = size
+	}
+	return out
+}
+
+// mainAxis takes a size and returns the main axis depending on the direction
+func (f FlexDirection) mainAxis(size vxfw.Size) (main uint16) {
+	switch f {
+	case FlexHorizontal:
+		main = size.Width
+	case FlexVertical:
+		main = size.Height
+	}
+	return
+}
+
+// max takes a size and a constraint and returns the max of size or constraint depending on the
+// direction
+func (f FlexDirection) max(size vxfw.Size, constraint uint16) uint16 {
+	if f == FlexHorizontal && size.Height > constraint {
+		return size.Height
+	} else if f == FlexVertical && size.Width > constraint {
+		return size.Width
+	}
+
+	return constraint
+}
+
+// size takes main and cross axis sizes a [vxfw.Size] depending on the direction
+func (f FlexDirection) size(main, cross uint16) (out vxfw.Size) {
+	switch f {
+	case FlexHorizontal:
+		out.Width, out.Height = main, cross
+	case FlexVertical:
+		out.Height, out.Width = main, cross
+	}
+	return
+}
+
+// flexOrigin takes a [vxfw.RelativePoint] and returns a new one where the Row or Col is adjusted
+// by offset based on the direction
+func (f FlexDirection) flexOrigin(origin vxfw.RelativePoint, offset int) (p vxfw.RelativePoint) {
+	p.Col, p.Row = origin.Col, origin.Row
+	switch f {
+	case FlexHorizontal:
+		p.Col += offset
+	case FlexVertical:
+		p.Row += offset
+	}
+	return
+}
+
+type FlexLayout struct {
+	Children  []*FlexItem
+	Direction FlexDirection
+}
+
+var _ vxfw.Widget = (*FlexLayout)(nil)
+
+func (w *FlexLayout) HandleEvent(_ vaxis.Event, _ vxfw.EventPhase) (vxfw.Command, error) {
+	return nil, nil
+}
+
+func (w *FlexLayout) Draw(ctx vxfw.DrawContext) (vxfw.Surface, error) {
+	// the accumulated size of all children in the first pass, this is their inherent size
+	first_pass_size := uint16(0)
+
+	// number of "flex units" opted in by the flex items
+	total_flex := uint16(0)
+
+	sizes := make([]uint16, len(w.Children))
+
+	// First pass: layout
+	// The layout pass draws each child assuming it had the full ctx to draw into to determine
+	// what size it would be if it was not sharing the space.
+	// We can use this information, plus the number of flex units, to determine how to distribute
+	// the space.
+
+	// Iterate over each child, draw it, and measure the flex direction
+	for i, child := range w.Children {
+		surface, err := child.Draw(ctx)
+		if err != nil {
+			return vxfw.Surface{}, err
+		}
+
+		inherent_size := w.Direction.mainAxis(surface.Size)
+		first_pass_size += inherent_size
+		sizes[i] = inherent_size
+		total_flex += uint16(child.Flex)
+	}
+
+	children := make([]vxfw.SubSurface, len(w.Children))
+	second_pass_size := uint16(0)
+
+	// The total size we can flex into along the main axis
+	max_flex_axis := w.Direction.mainAxis(ctx.Max)
+
+	// The largest size we've seen in the cross axis
+	max_cross_axis := uint16(0)
+
+	// Extra space left over that needs to be distributed
+	remaining := max_flex_axis - first_pass_size
+
+	for i, child := range w.Children {
+		inherent_size := sizes[i]
+		child_size := uint16(0)
+
+		if child.Flex == 0 {
+			child_size = inherent_size
+		} else if i == len(w.Children)-1 {
+			// last child gets the remaining space
+			child_size = max_flex_axis - second_pass_size
+		} else {
+			child_size = inherent_size + (remaining*uint16(child.Flex))/total_flex
+		}
+
+		childctx := w.Direction.flexContext(ctx, child_size)
+		surface, err := child.Draw(childctx)
+		if err != nil {
+			return vxfw.Surface{}, err
+		}
+
+		// flex the origin by the accumulated size of the second pass
+		origin := w.Direction.flexOrigin(vxfw.RelativePoint{}, int(second_pass_size))
+
+		children[i] = vxfw.SubSurface{
+			Origin:  origin,
+			Surface: surface,
+			ZIndex:  0,
+		}
+
+		// track the max of the cross axis
+		max_cross_axis = w.Direction.max(surface.Size, max_cross_axis)
+		second_pass_size += w.Direction.mainAxis(surface.Size)
+	}
+
+	return vxfw.Surface{
+		Size:     w.Direction.size(second_pass_size, max_cross_axis),
+		Widget:   w,
+		Buffer:   nil,
+		Children: children,
+	}, nil
+}

--- a/vxfw/vxlayout/flex_test.go
+++ b/vxfw/vxlayout/flex_test.go
@@ -1,0 +1,134 @@
+package vxlayout
+
+import (
+	"testing"
+
+	"git.sr.ht/~rockorager/vaxis"
+	"git.sr.ht/~rockorager/vaxis/vxfw"
+	"git.sr.ht/~rockorager/vaxis/vxfw/text"
+)
+
+func TestFlexRow(t *testing.T) {
+	row := FlexLayout{
+		Children: []*FlexItem{
+			{text.New("abc"), 0},
+			{text.New("def"), 1},
+			{text.New("ghi"), 1},
+			{text.New("jkl\nmno"), 1},
+		},
+		Direction: FlexHorizontal,
+	}
+
+	ctx := vxfw.DrawContext{Max: vxfw.Size{Width: 16, Height: 16}, Characters: vaxis.Characters}
+	surface, err := row.Draw(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if surface.Size.Width != 16 {
+		t.Logf("wrong flex width, got=%d, want=16", surface.Size.Width)
+		t.Fail()
+	}
+
+	if surface.Size.Height != 2 {
+		t.Logf("wrong flex height, got=%d, want=2", surface.Size.Height)
+		t.Fail()
+	}
+
+	if len(surface.Children) != 4 {
+		t.Logf("wrong number of flex children, got=%d, want=4", len(surface.Children))
+		t.Fail()
+	}
+
+	// col moves forward by the width of each child, used to assert origins
+	col := 0
+
+	// expected widths of each child
+	// first should be 3, as that's the width it asked for and it has flex=0
+	// the remaining all have flex=1 so the remaining space (16-12) is distributed with leftovers
+	// going to the last child, giving: 4, 4, and 5
+	widths := []uint16{
+		3,
+		3 + 1,
+		3 + 1,
+		3 + 1 + 1,
+	}
+
+	for i, want := range widths {
+		child := surface.Children[i]
+
+		got := child.Surface.Size.Width
+		if got != want {
+			t.Logf("wrong width for child %d, got=%d, want=%d", i, got, want)
+			t.Fail()
+		}
+		if child.Origin.Col != col {
+			t.Logf("wrong origin for child %d, got=%d, want=%d", i, child.Origin.Col, col)
+			t.Fail()
+		}
+		col += int(want)
+	}
+}
+
+func TestFlexColumn(t *testing.T) {
+	layout := FlexLayout{
+		Children: []*FlexItem{
+			{text.New("abc"), 0},
+			{text.New("def"), 1},
+			{text.New("ghi"), 1},
+			{text.New("jkl\nmno"), 1},
+		},
+		Direction: FlexVertical,
+	}
+
+	ctx := vxfw.DrawContext{Max: vxfw.Size{Width: 16, Height: 16}, Characters: vaxis.Characters}
+	surface, err := layout.Draw(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if surface.Size.Width != 3 {
+		t.Logf("wrong flex width, got=%d, want=3", surface.Size.Width)
+		t.Fail()
+	}
+
+	if surface.Size.Height != 16 {
+		t.Logf("wrong flex height, got=%d, want=16", surface.Size.Height)
+		t.Fail()
+	}
+
+	if len(surface.Children) != 4 {
+		t.Logf("wrong number of flex children, got=%d, want=4", len(surface.Children))
+		t.Fail()
+	}
+
+	// row moves forward by the height of each child, used to assert origins
+	row := 0
+
+	// expected heights of each child
+	// inherent sizes are 1+1+1+2, leaving 16-(1+1+1+2)=11 rows for flex
+	// first child gets 1 row due to flex=0
+	// next three have flex=1 so they split the remaining 11 with 3 each, and the leftover 2 is
+	// given to the last child
+	heights := []uint16{
+		1,
+		1 + 3,
+		1 + 3,
+		2 + 3 + 2,
+	}
+
+	for i, want := range heights {
+		child := surface.Children[i]
+
+		got := child.Surface.Size.Height
+		if got != want {
+			t.Logf("wrong height for child %d, got=%d, want=%d", i, got, want)
+			t.Fail()
+		}
+		if child.Origin.Row != row {
+			t.Logf("wrong origin for child %d, got=%d, want=%d", i, child.Origin.Row, row)
+			t.Fail()
+		}
+		row += int(want)
+	}
+}


### PR DESCRIPTION
This started as a nearly line-by-line port of [FlexRow.zig](https://github.com/rockorager/libvaxis/blob/main/src/vxfw/FlexRow.zig).

After getting that working, I realized that `FlexColumn` is the same implementation...just swap the flex vs other dimensions so I introduced a `FlexDirection` enum with helper functions to calculate constraints, offsets, etc.

The two test cases are adapted from the zig implementation, and during testing we discovered that `vxfw.Text` and `vxfw.Richtext` were not meeting the minimum size constraints, so those were both fixed.