### PR TITLE
vxfw: separate out HandleEvent into an optional interface

### DIFF
--- a/vxfw/center/center.go
+++ b/vxfw/center/center.go
@@ -1,17 +1,12 @@
 package center
 
 import (
-	"git.sr.ht/~rockorager/vaxis"
 	"git.sr.ht/~rockorager/vaxis/vxfw"
 )
 
 // Center draws the child centered within the space given to Center
 type Center struct {
 	Child vxfw.Widget
-}
-
-func (c *Center) HandleEvent(ev vaxis.Event, ph vxfw.EventPhase) (vxfw.Command, error) {
-	return nil, nil
 }
 
 func (c *Center) Draw(ctx vxfw.DrawContext) (vxfw.Surface, error) {

--- a/vxfw/richtext/richtext.go
+++ b/vxfw/richtext/richtext.go
@@ -24,11 +24,6 @@ func New(segments []vaxis.Segment) *RichText {
 	}
 }
 
-// Noop for text
-func (t *RichText) HandleEvent(ev vaxis.Event, phase vxfw.EventPhase) (vxfw.Command, error) {
-	return nil, nil
-}
-
 func (t *RichText) cells(ctx vxfw.DrawContext) []vaxis.Cell {
 	cells := []vaxis.Cell{}
 	for _, seg := range t.Content {

--- a/vxfw/text/text.go
+++ b/vxfw/text/text.go
@@ -30,11 +30,6 @@ func New(content string) *Text {
 	}
 }
 
-// Noop for text
-func (t *Text) HandleEvent(ev vaxis.Event, phase vxfw.EventPhase) (vxfw.Command, error) {
-	return nil, nil
-}
-
 func (t *Text) Draw(ctx vxfw.DrawContext) (vxfw.Surface, error) {
 	if t.Softwrap {
 		return t.drawSoftwrap(ctx)

--- a/vxfw/vxfw.go
+++ b/vxfw/vxfw.go
@@ -11,7 +11,6 @@ import (
 )
 
 type Widget interface {
-	HandleEvent(vaxis.Event, EventPhase) (Command, error)
 	Draw(DrawContext) (Surface, error)
 }
 
@@ -20,6 +19,12 @@ type Widget interface {
 // ancestor of the target widget
 type EventCapturer interface {
 	CaptureEvent(vaxis.Event) (Command, error)
+}
+
+// EventHandler is a Widget which can handle events. It's a separate interface to simplify creating
+// custom [Widget]s that do not require event handling.
+type EventHandler interface {
+	HandleEvent(vaxis.Event, EventPhase) (Command, error)
 }
 
 type Event interface{}
@@ -275,7 +280,7 @@ func (f *focusHandler) handleEvent(app *App, ev vaxis.Event) error {
 	}
 
 	// Target phase
-	cmd, err := f.focused.HandleEvent(ev, TargetPhase)
+	cmd, err := tryHandleEvent(f.focused, ev, TargetPhase)
 	if err != nil {
 		return err
 	}
@@ -285,11 +290,11 @@ func (f *focusHandler) handleEvent(app *App, ev vaxis.Event) error {
 		return nil
 	}
 
-	// Bubble phase. We don't bubble to the focused widget (which is the
-	// last one in the list). Hence, - 2
+	// Bubble phase. We don't bubble to the focused widget (which is the last one in the list).
+	// Hence, - 2
 	for i := len(f.path) - 2; i >= 0; i -= 1 {
 		w := f.path[i]
-		cmd, err := w.HandleEvent(ev, BubblePhase)
+		cmd, err = tryHandleEvent(w, ev, BubblePhase)
 		if err != nil {
 			return err
 		}
@@ -351,22 +356,35 @@ func (f *focusHandler) focusWidget(app *App, w Widget) error {
 		return nil
 	}
 
-	cmd, err := f.focused.HandleEvent(vaxis.FocusOut{}, TargetPhase)
+	cmd, err := tryHandleEvent(f.focused, vaxis.FocusOut{}, TargetPhase)
 	if err != nil {
 		return err
 	}
 	app.handleCommand(cmd)
+
 	// Change the focused widget before we send the focus in event. If the
 	// newly focused widget changes focus again, we need to set this before
 	// the handleCommand call
 	f.focused = w
-	cmd, err = w.HandleEvent(vaxis.FocusIn{}, TargetPhase)
+	cmd, err = tryHandleEvent(w, vaxis.FocusIn{}, TargetPhase)
 	if err != nil {
 		return err
 	}
 	app.handleCommand(cmd)
 
 	return nil
+}
+
+// tryHandleEvent calls HandleEvent on w, if w is an [EventHandler]
+// If w is not an EventHandler, tryHandleEvent returns nil, nil.
+// Otherwise, tryHandleEvent returns the [Command] and error from HandleEvent.
+func tryHandleEvent(w Widget, event vaxis.Event, phase EventPhase) (Command, error) {
+	eh, ok := w.(EventHandler)
+	if !ok {
+		return nil, nil
+	}
+
+	return eh.HandleEvent(event, phase)
 }
 
 type App struct {
@@ -446,7 +464,7 @@ func (a *App) Run(w Widget) error {
 					return err
 				}
 			case vaxis.FocusIn:
-				cmd, err := w.HandleEvent(MouseEnter{}, TargetPhase)
+				cmd, err := tryHandleEvent(w, MouseEnter{}, TargetPhase)
 				if err != nil {
 					return err
 				}
@@ -652,7 +670,7 @@ func (m *mouseHandler) handleEvent(app *App, ev vaxis.Mouse) error {
 	target := m.lastHits[len(m.lastHits)-1]
 
 	// Target phase
-	cmd, err := target.w.HandleEvent(ev, TargetPhase)
+	cmd, err := tryHandleEvent(target.w, ev, TargetPhase)
 	if err != nil {
 		return err
 	}
@@ -666,7 +684,7 @@ func (m *mouseHandler) handleEvent(app *App, ev vaxis.Mouse) error {
 	// last one in the list). Hence, - 2
 	for i := len(m.lastHits) - 2; i >= 0; i -= 1 {
 		h := m.lastHits[i]
-		cmd, err := h.w.HandleEvent(ev, BubblePhase)
+		cmd, err := tryHandleEvent(h.w, ev, BubblePhase)
 		if err != nil {
 			return err
 		}
@@ -707,7 +725,7 @@ outer_exit:
 		}
 		// h1 was not found in the new hitlist send it a mouse leave
 		// event
-		cmd, err := h1.w.HandleEvent(MouseLeave{}, TargetPhase)
+		cmd, err := tryHandleEvent(h1.w, MouseLeave{}, TargetPhase)
 		if err != nil {
 			return err
 		}
@@ -725,7 +743,7 @@ outer_enter:
 		}
 		// h1 was not found in the old hitlist send it a mouse enter
 		// event
-		cmd, err := h1.w.HandleEvent(MouseEnter{}, TargetPhase)
+		cmd, err := tryHandleEvent(h1.w, MouseEnter{}, TargetPhase)
 		if err != nil {
 			return err
 		}
@@ -741,7 +759,7 @@ outer_enter:
 // mouseExit send a mouseLeave event to each widget in the last hit list
 func (m *mouseHandler) mouseExit(app *App) error {
 	for _, h := range m.lastHits {
-		cmd, err := h.w.HandleEvent(MouseLeave{}, TargetPhase)
+		cmd, err := tryHandleEvent(h.w, MouseLeave{}, TargetPhase)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Lots of custom widgets won't need to handle any events, so let's make it optional.

Since `vxfw.App` already handles capturing towards the focus and bubbling up from the focus, it's simple enough to treat `HandleEvent` the same as `CaptureEvent`, although in the former case it's via a `tryHandleEvent` since it's called much more frequently.