### PR TITLE
vxfw: clip surfaces to fit the parent in the main render loop

### DIFF
--- a/vxfw/vxfw.go
+++ b/vxfw/vxfw.go
@@ -198,11 +198,15 @@ func (s Surface) render(win vaxis.Window, focused Widget) {
 	})
 
 	for _, child := range s.Children {
+		// clip the child window to the minimum of the parent surface or the child surface this
+		// effectively forces clipping at the layout level
+		w := math.Min(float64(child.Surface.Size.Width), float64(int(s.Size.Width)-child.Origin.Col))
+		h := math.Min(float64(child.Surface.Size.Height), float64(int(s.Size.Height)-child.Origin.Row))
 		childWin := win.New(
 			int(child.Origin.Col),
 			int(child.Origin.Row),
-			int(child.Surface.Size.Width),
-			int(child.Surface.Size.Height),
+			int(w),
+			int(h),
 		)
 		child.Surface.render(childWin, focused)
 	}


### PR DESCRIPTION
While working on the flex example in #18 I noticed that I had a root-level surface tree that looked like:

- root: width=16, height=max
  - help: width=max, height=1
  - flex: width=16, height=max

When that was rendered, the help was rendered full width, even though the root surface had a width of 16 columns.

I figured there were two places to clip, either in `Surface.AddChild` or in the main render loop and decided to do it in the latter.