### PR TITLE
fix(vxfw): ensure widgets satisfy minimum draw context

### DIFF
--- a/vxfw/richtext/richtext.go
+++ b/vxfw/richtext/richtext.go
@@ -143,6 +143,12 @@ func (t *RichText) findContainerSize(cells []vaxis.Cell, ctx vxfw.DrawContext) v
 				size.Width = ctx.Max.Width
 			}
 		}
+		if size.Width < ctx.Min.Width {
+			size.Width = ctx.Min.Width
+		}
+		if size.Height < ctx.Min.Height {
+			size.Height = ctx.Min.Height
+		}
 		return size
 	}
 
@@ -164,6 +170,12 @@ func (t *RichText) findContainerSize(cells []vaxis.Cell, ctx vxfw.DrawContext) v
 		if size.Width > ctx.Max.Width {
 			size.Width = ctx.Max.Width
 		}
+	}
+	if size.Width < ctx.Min.Width {
+		size.Width = ctx.Min.Width
+	}
+	if size.Height < ctx.Min.Height {
+		size.Height = ctx.Min.Height
 	}
 
 	return size

--- a/vxfw/text/text.go
+++ b/vxfw/text/text.go
@@ -141,6 +141,12 @@ func (t *Text) findContainerSize(ctx vxfw.DrawContext) vxfw.Size {
 				size.Width = ctx.Max.Width
 			}
 		}
+		if size.Width < ctx.Min.Width {
+			size.Width = ctx.Min.Width
+		}
+		if size.Height < ctx.Min.Height {
+			size.Height = ctx.Min.Height
+		}
 		return size
 	}
 	scanner := bufio.NewScanner(strings.NewReader(t.Content))
@@ -161,6 +167,12 @@ func (t *Text) findContainerSize(ctx vxfw.DrawContext) vxfw.Size {
 		if size.Width > ctx.Max.Width {
 			size.Width = ctx.Max.Width
 		}
+	}
+	if size.Width < ctx.Min.Width {
+		size.Width = ctx.Min.Width
+	}
+	if size.Height < ctx.Min.Height {
+		size.Height = ctx.Min.Height
 	}
 
 	return size

--- a/vxfw/textfield/textfield.go
+++ b/vxfw/textfield/textfield.go
@@ -220,7 +220,12 @@ func (tf *TextField) Draw(ctx vxfw.DrawContext) (vxfw.Surface, error) {
 		return vxfw.Surface{}, nil
 	}
 
-	s := vxfw.NewSurface(ctx.Max.Width, 1, tf)
+	height := uint16(1)
+	if ctx.Min.Height < height {
+		height = ctx.Min.Height
+	}
+
+	s := vxfw.NewSurface(ctx.Max.Width, height, tf)
 	s.Cursor = &vxfw.CursorState{
 		Row:   0,
 		Col:   0,

--- a/vxfw/widget_size_test.go
+++ b/vxfw/widget_size_test.go
@@ -1,0 +1,101 @@
+package vxfw_test // _test package to avoid import cycles
+
+import (
+	"strings"
+	"testing"
+
+	"git.sr.ht/~rockorager/vaxis"
+	"git.sr.ht/~rockorager/vaxis/vxfw"
+	"git.sr.ht/~rockorager/vaxis/vxfw/button"
+	"git.sr.ht/~rockorager/vaxis/vxfw/center"
+	"git.sr.ht/~rockorager/vaxis/vxfw/list"
+	"git.sr.ht/~rockorager/vaxis/vxfw/richtext"
+	"git.sr.ht/~rockorager/vaxis/vxfw/text"
+)
+
+func TestWidgetConstraints(t *testing.T) {
+	lt := func(t *testing.T, lhs, rhs uint16, dim string) {
+		t.Helper()
+
+		if lhs <= rhs {
+			return
+		}
+
+		t.Fail()
+		t.Logf("%s check failed, %d is not less than %d", dim, lhs, rhs)
+	}
+
+	ctx := vxfw.DrawContext{
+		Min:        vxfw.Size{Width: 4, Height: 4},
+		Max:        vxfw.Size{Width: 16, Height: 16},
+		Characters: vaxis.Characters,
+	}
+
+	short := "_"
+	long := strings.Repeat(short, 256)
+
+	testcases := []struct {
+		name   string
+		widget vxfw.Widget
+	}{{
+		"text",
+		text.New(short),
+	}, {
+		"text-long",
+		text.New(long),
+	}, {
+		"richtext",
+		richtext.New([]vaxis.Segment{{Text: short}}),
+	}, {
+		"richtext-long",
+		richtext.New([]vaxis.Segment{{Text: long}}),
+	}, {
+		"center",
+		&center.Center{Child: text.New(short)},
+	}, {
+		"center-long",
+		&center.Center{Child: text.New(long)},
+	}, {
+		"button",
+		&button.Button{Label: short},
+	}, {
+		"button-long",
+		&button.Button{Label: long},
+	}, {
+		"list",
+		&list.Dynamic{
+			Builder: func(i, _ uint) vxfw.Widget {
+				if i == 1 {
+					return text.New(short)
+				}
+				return nil
+			},
+		},
+	}, {
+		"list-long",
+		&list.Dynamic{
+			Builder: func(i, _ uint) vxfw.Widget {
+				return text.New(long)
+			},
+		},
+	}}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			surface, err := tc.widget.Draw(ctx)
+			if err != nil {
+				t.Fatalf("unexpected error calling Draw: %v", err)
+			}
+
+			sz := surface.Size
+			min := ctx.Min
+			max := ctx.Max
+
+			lt(t, min.Width, sz.Width, "min-width")
+			lt(t, min.Height, sz.Height, "min-height")
+
+			lt(t, sz.Width, max.Width, "max-width")
+			lt(t, sz.Height, max.Height, "max-height")
+		})
+	}
+}


### PR DESCRIPTION
text, textfield, and textinput all customize their surface size and have the potential of returning a surface smaller than the minimum supplied in the draw context, which can mess with layouts.

This commit also includes a test that renders each widget with both short and long content and checks the returned surface.