### PR TITLE
vxfw: add vxlayout.Spacer as a convenience for filling flex space

### DIFF
--- a/_examples/vxfw/flex/main.go
+++ b/_examples/vxfw/flex/main.go
@@ -5,7 +5,6 @@ import (
 
 	"git.sr.ht/~rockorager/vaxis"
 	"git.sr.ht/~rockorager/vaxis/vxfw"
-	"git.sr.ht/~rockorager/vaxis/vxfw/center"
 	"git.sr.ht/~rockorager/vaxis/vxfw/richtext"
 	"git.sr.ht/~rockorager/vaxis/vxfw/text"
 	"git.sr.ht/~rockorager/vaxis/vxfw/vxlayout"
@@ -80,9 +79,9 @@ func main() {
 		richtext.New([]vaxis.Segment{
 			{Text: "FIRST", Style: vaxis.Style{Background: vaxis.IndexColor(1)}},
 		}),
-		&center.Center{Child: richtext.New([]vaxis.Segment{
+		richtext.New([]vaxis.Segment{
 			{Text: "MIDDLE", Style: vaxis.Style{Background: vaxis.IndexColor(2)}},
-		})},
+		}),
 		richtext.New([]vaxis.Segment{
 			{Text: "LAST", Style: vaxis.Style{Background: vaxis.IndexColor(3)}},
 		}),
@@ -93,7 +92,9 @@ func main() {
 		layout: &vxlayout.FlexLayout{
 			Children: []*vxlayout.FlexItem{
 				{Widget: widgets[0], Flex: 0},
-				{Widget: widgets[1], Flex: 1},
+				vxlayout.MustSpacer(1),
+				{Widget: widgets[1], Flex: 0},
+				{Widget: vxlayout.Spacer{}, Flex: 1},
 				{Widget: widgets[2], Flex: 0},
 			},
 			Direction: vxlayout.FlexHorizontal,

--- a/vxfw/vxlayout/spacer.go
+++ b/vxfw/vxlayout/spacer.go
@@ -1,0 +1,40 @@
+package vxlayout
+
+import (
+	"fmt"
+
+	"git.sr.ht/~rockorager/vaxis"
+	"git.sr.ht/~rockorager/vaxis/vxfw"
+)
+
+// Spacer is a [vxfw.Widget] that takes up available space. It should be used in
+// a [FlexItem] with a flex of at least 1.
+// Use [NewSpacer] or [MustSpacer] for a [FlexItem] that can be passed directly to [FlexLayout]
+type Spacer struct{}
+
+// NewSpacer returns a FlexItem that fills available flex space based on the value of flex.
+// It is an error to pass a flex less than 1.
+func NewSpacer(flex uint8) (*FlexItem, error) {
+	if flex < 1 {
+		return nil, fmt.Errorf("spacer flex must be at least 1, got: %d", flex)
+	}
+
+	return &FlexItem{
+		Widget: Spacer{},
+		Flex:   flex,
+	}, nil
+}
+
+// MustSpacer is like NewSpacer, but panics if flex is less than 1.
+func MustSpacer(flex uint8) *FlexItem {
+	w, err := NewSpacer(flex)
+	if err != nil {
+		panic(err)
+	}
+	return w
+}
+
+func (s Spacer) HandleEvent(_ vaxis.Event, _ vxfw.EventPhase) (vxfw.Command, error) { return nil, nil }
+func (s Spacer) Draw(ctx vxfw.DrawContext) (vxfw.Surface, error) {
+	return vxfw.NewSurface(ctx.Min.Width, ctx.Min.Height, s), nil
+}


### PR DESCRIPTION
The updated example shows two uses of the spacer, one via `vxlayout.MustSpacer` and the other via direct construction of `vxlayout.FlexItem` with a spacer.