### PR TITLE
fix(vxfw/list): allow list elements to be size 0

### DIFF
--- a/vxfw/list/list.go
+++ b/vxfw/list/list.go
@@ -167,8 +167,7 @@ func (d *Dynamic) Draw(ctx vxfw.DrawContext) (vxfw.Surface, error) {
 		// Increment the index
 		i += 1
 
-		// Set up constraints
-		chCtx := ctx.WithMax(vxfw.Size{
+		chCtx := ctx.WithConstraints(vxfw.Size{}, vxfw.Size{
 			Width:  ctx.Max.Width - uint16(colOffset),
 			Height: math.MaxUint16,
 		})


### PR DESCRIPTION
After a flex layout computes widget sizing, it re-renders each widget with the min and max set to the same value. In the case of a list, this tight constraint was being passed to the children, and then each child was rendering itself with min==max, resulting in *each* child taking up the full flex area.