### PR TITLE
vxfw: add WidgetFunc and EventHandlerFunc

### DIFF
--- a/vxfw/vxfw.go
+++ b/vxfw/vxfw.go
@@ -14,6 +14,14 @@ type Widget interface {
 	Draw(DrawContext) (Surface, error)
 }
 
+// WidgetFunc is a convenience function for making stateless widgets.
+// It converts a standard Draw function signature into a [Widget].
+type WidgetFunc func(DrawContext) (Surface, error)
+
+func (fn WidgetFunc) Draw(ctx DrawContext) (Surface, error) {
+	return fn(ctx)
+}
+
 // EventCapturer is a Widget which can capture events before they are delivered
 // to the target widget. To capture an event, the EventCapturer must be an
 // ancestor of the target widget
@@ -26,6 +34,16 @@ type EventCapturer interface {
 type EventHandler interface {
 	HandleEvent(vaxis.Event, EventPhase) (Command, error)
 }
+
+// EventHandlerFunc is a convenience function for making stateless event handlers.
+// It can also be used in a [Widget] to define several event handlers for stateless child widgets
+// created with [WidgetFunc]
+type EventHandlerFunc func(vaxis.Event, EventPhase) (Command, error)
+
+func (fn EventHandlerFunc) HandleEvent(event vaxis.Event, phase EventPhase) (Command, error) {
+	return fn(event, phase)
+}
+func (fn EventHandlerFunc) Draw(_ DrawContext) (Surface, error) { return Surface{}, nil }
 
 type Event interface{}
 


### PR DESCRIPTION
I first introduced `WidgetFunc` in #25 where I used it to create simple widgets like `Fill`:

```go
func Fill(cell vaxis.Cell) vxfw.Widget {
	return vxfw.WidgetFunc(func(ctx vxfw.DrawContext) (vxfw.Surface, error) {
		surface := vxfw.NewSurface(ctx.Max.Width, ctx.Max.Height, nil)
		surface.Fill(cell)
		return surface, nil
	})
}
```

On that PR, @apprehensions suggested stateless event handlers as well, which is what prompted me to create this PR.

What's become more clear to me as I've worked on `vxlayout` is how simple the main loop is. The "layout mantra" of Flutter is:

> Constraints go down. Sizes come up. Parent sets position.

If you reword it for `vxfw`, it's:

> DrawContexts go down. Surfaces come up. Parent sets position.

Even more relevant to this issue is that while `Surface` takes a `Widget`, it doesn't actually *do* anything with that widget *other than call HandleEvent*. If you have a widget that doesn't need to handle events, you can just set the widget to `nil` in the call to `NewSurface`.

So: constraints go down, surfaces with event handlers come up.