### PR TITLE
vxfw: add image widget

### DIFF
--- a/image.go
+++ b/image.go
@@ -65,6 +65,10 @@ type KittyImage struct {
 	id       uint64
 	w        int
 	h        int
+	reqW     int
+	reqH     int
+	cellPixW int
+	cellPixH int
 	uploaded int32
 	encoding int32
 	buf      *bytes.Buffer
@@ -84,6 +88,10 @@ func (vx *Vaxis) NewKittyGraphic(img image.Image) *KittyImage {
 // Draw draws the [Image] to the [Window].
 func (k *KittyImage) Draw(win Window) {
 	if atomicLoad(&k.encoding) {
+		return
+	}
+	if k.reqW != 0 && k.reqH != 0 && k.cellSizeChanged() {
+		k.Resize(k.reqW, k.reqH)
 		return
 	}
 	col, row := win.Origin()
@@ -123,6 +131,12 @@ func (k *KittyImage) CellSize() (w int, h int) {
 	return k.w, k.h
 }
 
+func (k *KittyImage) cellSizeChanged() bool {
+	cellPixW := k.vx.winSize.XPixel / k.vx.winSize.Cols
+	cellPixH := k.vx.winSize.YPixel / k.vx.winSize.Rows
+	return k.cellPixW != cellPixW || k.cellPixH != cellPixH
+}
+
 // Resizes the image to fit within the wxh area. The image will not be
 // upscaled, nor will it's aspect ratio be changed. Resizing will be done in a
 // separate goroutine. A [Redraw] event will be posted when complete
@@ -130,6 +144,13 @@ func (k *KittyImage) Resize(w int, h int) {
 	// Resize the image
 	cellPixW := k.vx.winSize.XPixel / k.vx.winSize.Cols
 	cellPixH := k.vx.winSize.YPixel / k.vx.winSize.Rows
+	if k.reqW == w && k.reqH == h && k.cellPixW == cellPixW && k.cellPixH == cellPixH && k.buf.Len() == 0 && atomicLoad(&k.uploaded) {
+		return
+	}
+	k.reqW = w
+	k.reqH = h
+	k.cellPixW = cellPixW
+	k.cellPixH = cellPixH
 	img := resizeImage(k.img, w, h, cellPixW, cellPixH)
 
 	// Reupload the image
@@ -179,6 +200,10 @@ type Sixel struct {
 	id       uint64
 	w        int
 	h        int
+	reqW     int
+	reqH     int
+	cellPixW int
+	cellPixH int
 	encoding int32
 }
 
@@ -186,6 +211,10 @@ type Sixel struct {
 // if it is larger than the window
 func (s *Sixel) Draw(win Window) {
 	if atomicLoad(&s.encoding) {
+		return
+	}
+	if s.reqW != 0 && s.reqH != 0 && s.cellSizeChanged() {
+		s.Resize(s.reqW, s.reqH)
 		return
 	}
 	if s.buf.Len() == 0 {
@@ -213,11 +242,13 @@ func (s *Sixel) Draw(win Window) {
 		}
 		w.Write(s.buf.Bytes())
 	}
-	deleteFunc := func(_ io.Writer) {
-		// no-op. we expect users to Clear the screen or just print
-		// cells, which will have the effect of clearing the sixel
-	}
 	col, row := win.Origin()
+	pw, ph := s.w, s.h
+	deleteFunc := func(w io.Writer) {
+		for y := 0; y < ph; y += 1 {
+			fmt.Fprintf(w, "\x1b[%d;%dH%*s", row+y+1, col+1, pw, "")
+		}
+	}
 	log.Trace("placing sixel image at cell %d,%d", col, row)
 	placement := &placement{
 		col:      col,
@@ -240,12 +271,19 @@ func (s *Sixel) Destroy() {
 // upscaled, nor will it's aspect ratio be changed. Resize will be done in a
 // separate gorotuine. A Redraw event will be posted when complete
 func (s *Sixel) Resize(w int, h int) {
+	cellPixW := s.vx.winSize.XPixel / s.vx.winSize.Cols
+	cellPixH := s.vx.winSize.YPixel / s.vx.winSize.Rows
+	if s.reqW == w && s.reqH == h && s.cellPixW == cellPixW && s.cellPixH == cellPixH && s.buf.Len() != 0 {
+		return
+	}
+	s.reqW = w
+	s.reqH = h
+	s.cellPixW = cellPixW
+	s.cellPixH = cellPixH
 	atomicStore(&s.encoding, true)
 	go func() {
 		defer atomicStore(&s.encoding, false)
 		// Resize the image
-		cellPixW := s.vx.winSize.XPixel / s.vx.winSize.Cols
-		cellPixH := s.vx.winSize.YPixel / s.vx.winSize.Rows
 		img := resizeImage(s.img, w, h, cellPixW, cellPixH)
 		max := img.Bounds().Max
 		s.w = max.X / cellPixW
@@ -289,6 +327,12 @@ func (s *Sixel) CellSize() (w int, h int) {
 		return
 	}
 	return s.w, s.h
+}
+
+func (s *Sixel) cellSizeChanged() bool {
+	cellPixW := s.vx.winSize.XPixel / s.vx.winSize.Cols
+	cellPixH := s.vx.winSize.YPixel / s.vx.winSize.Rows
+	return s.cellPixW != cellPixW || s.cellPixH != cellPixH
 }
 
 func (vx *Vaxis) NewSixel(img image.Image) *Sixel {

--- a/vaxis.go
+++ b/vaxis.go
@@ -469,9 +469,11 @@ func (vx *Vaxis) Render() {
 			log.Error("couldn't report winsize: %v", err)
 			return
 		}
-		if ws.Cols != vx.winSize.Cols || ws.Rows != vx.winSize.Rows {
-			vx.screenNext.resize(ws.Cols, ws.Rows)
-			vx.screenLast.resize(ws.Cols, ws.Rows)
+		if ws.Cols != vx.winSize.Cols || ws.Rows != vx.winSize.Rows || ws.XPixel != vx.winSize.XPixel || ws.YPixel != vx.winSize.YPixel {
+			if ws.Cols != vx.winSize.Cols || ws.Rows != vx.winSize.Rows {
+				vx.screenNext.resize(ws.Cols, ws.Rows)
+				vx.screenLast.resize(ws.Cols, ws.Rows)
+			}
 			vx.winSize = ws
 			vx.refresh = true
 			vx.PostEvent(vx.winSize)

--- a/vxfw/image/image.go
+++ b/vxfw/image/image.go
@@ -1,0 +1,82 @@
+// Package image provides a vxfw widget for rendering vaxis images.
+package image
+
+import (
+	"math"
+
+	"git.sr.ht/~rockorager/vaxis"
+	"git.sr.ht/~rockorager/vaxis/vxfw"
+)
+
+// Image displays a vaxis.Image in a vxfw widget tree.
+type Image struct {
+	Image vaxis.Image
+
+	preferredW  int
+	preferredH  int
+	lastResizeW int
+	lastResizeH int
+}
+
+func New(img vaxis.Image) *Image {
+	return &Image{Image: img}
+}
+
+func (i *Image) Draw(ctx vxfw.DrawContext) (vxfw.Surface, error) {
+	width, height := i.size(ctx)
+	s := vxfw.NewSurface(width, height, i)
+	s.Render = func(win vaxis.Window) {
+		if i.Image == nil {
+			return
+		}
+		if i.lastResizeW != int(width) || i.lastResizeH != int(height) {
+			i.Image.Resize(int(width), int(height))
+			i.lastResizeW = int(width)
+			i.lastResizeH = int(height)
+		}
+		i.Image.Draw(win)
+	}
+	return s, nil
+}
+
+func (i *Image) size(ctx vxfw.DrawContext) (uint16, uint16) {
+	var width, height uint16
+	if i.Image != nil {
+		w, h := i.Image.CellSize()
+		if w > i.preferredW {
+			i.preferredW = w
+		}
+		if h > i.preferredH {
+			i.preferredH = h
+		}
+		width = clampInt(i.preferredW, ctx.Min.Width, ctx.Max.Width)
+		height = clampInt(i.preferredH, ctx.Min.Height, ctx.Max.Height)
+	}
+	if width == 0 {
+		width = fallbackSize(ctx.Min.Width, ctx.Max.Width)
+	}
+	if height == 0 {
+		height = fallbackSize(ctx.Min.Height, ctx.Max.Height)
+	}
+	return width, height
+}
+
+func fallbackSize(minimum, maximum uint16) uint16 {
+	if maximum != math.MaxUint16 {
+		return max(minimum, maximum)
+	}
+	return minimum
+}
+
+func clampInt(v int, minimum, maximum uint16) uint16 {
+	if v < 0 {
+		v = 0
+	}
+	if v < int(minimum) {
+		v = int(minimum)
+	}
+	if maximum != math.MaxUint16 && v > int(maximum) {
+		v = int(maximum)
+	}
+	return uint16(v)
+}

--- a/vxfw/image/image_test.go
+++ b/vxfw/image/image_test.go
@@ -1,0 +1,90 @@
+package image_test
+
+import (
+	"testing"
+
+	"git.sr.ht/~rockorager/vaxis"
+	"git.sr.ht/~rockorager/vaxis/vxfw"
+	vxfwimage "git.sr.ht/~rockorager/vaxis/vxfw/image"
+)
+
+type fakeImage struct {
+	resizeW int
+	resizeH int
+	drawn   bool
+	cellW   int
+	cellH   int
+}
+
+func (f *fakeImage) Draw(vaxis.Window) {
+	f.drawn = true
+}
+
+func (f *fakeImage) Destroy() {}
+
+func (f *fakeImage) Resize(w int, h int) {
+	f.resizeW = w
+	f.resizeH = h
+	f.cellW = w
+	f.cellH = h
+}
+
+func (f *fakeImage) CellSize() (int, int) {
+	return f.cellW, f.cellH
+}
+
+func TestImageDraw(t *testing.T) {
+	img := &fakeImage{cellW: 40, cellH: 20}
+	widget := vxfwimage.New(img)
+
+	s, err := widget.Draw(vxfw.DrawContext{
+		Min: vxfw.Size{},
+		Max: vxfw.Size{Width: 10, Height: 5},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.Size != (vxfw.Size{Width: 10, Height: 5}) {
+		t.Fatalf("unexpected surface size: %#v", s.Size)
+	}
+	if s.Render == nil {
+		t.Fatal("expected image surface to have a render hook")
+	}
+
+	s.Render(vaxis.Window{})
+	if !img.drawn {
+		t.Fatal("expected render hook to draw image")
+	}
+	if img.resizeW != 10 || img.resizeH != 5 {
+		t.Fatalf("expected resize to 10x5, got %dx%d", img.resizeW, img.resizeH)
+	}
+}
+
+func TestImageCanGrowAfterShrink(t *testing.T) {
+	img := &fakeImage{cellW: 40, cellH: 20}
+	widget := vxfwimage.New(img)
+
+	s, err := widget.Draw(vxfw.DrawContext{
+		Min: vxfw.Size{},
+		Max: vxfw.Size{Width: 10, Height: 5},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.Render(vaxis.Window{})
+
+	s, err = widget.Draw(vxfw.DrawContext{
+		Min: vxfw.Size{},
+		Max: vxfw.Size{Width: 30, Height: 15},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.Size != (vxfw.Size{Width: 30, Height: 15}) {
+		t.Fatalf("unexpected surface size after growing: %#v", s.Size)
+	}
+	s.Render(vaxis.Window{})
+	if img.resizeW != 30 || img.resizeH != 15 {
+		t.Fatalf("expected resize to 30x15, got %dx%d", img.resizeW, img.resizeH)
+	}
+}

--- a/vxfw/vxfw.go
+++ b/vxfw/vxfw.go
@@ -1,6 +1,7 @@
 package vxfw
 
 import (
+	"image"
 	"math"
 	"sort"
 	"strings"
@@ -129,6 +130,7 @@ type Surface struct {
 	Cursor   *CursorState
 	Buffer   []vaxis.Cell
 	Children []SubSurface
+	Render   func(vaxis.Window)
 }
 
 // Creates a new surface. The resulting surface will have a Buffer with capacity
@@ -188,6 +190,10 @@ func (s Surface) render(win vaxis.Window, focused Widget) {
 		row := i / int(s.Size.Width)
 		col := i % int(s.Size.Width)
 		win.SetCell(col, row, cell)
+	}
+
+	if s.Render != nil {
+		s.Render(win)
 	}
 
 	// If we have a cursor state and we are the focused widget, draw the
@@ -425,6 +431,13 @@ func (a *App) Suspend() error {
 
 func (a *App) Resume() error {
 	return a.vx.Resume()
+}
+
+// NewImage creates a new image using the highest quality renderer the terminal
+// is capable of. The returned image can be displayed with the vxfw/image
+// widget.
+func (a *App) NewImage(img image.Image) (vaxis.Image, error) {
+	return a.vx.NewImage(img)
 }
 
 // Run the application


### PR DESCRIPTION
Adds image support for vxfw by introducing a render hook on Surface and a new vxfw/image widget.

The render hook lets widgets that need an actual vaxis.Window participate in the render pass. The image widget uses it to resize and draw a vaxis.Image, which lets kitty/sixel placements continue through the existing Vaxis rendering path.

Also adds App.NewImage so vxfw users can create a vaxis.Image without direct access to the private Vaxis instance.

Fixes #27.

Tests: go test ./...