### PR TITLE
vxfw/list: check if scroll is within cursor bound

### DIFF
--- a/vxfw/list/list.go
+++ b/vxfw/list/list.go
@@ -215,7 +215,7 @@ func (d *Dynamic) Draw(ctx vxfw.DrawContext) (vxfw.Surface, error) {
 		idx := d.cursor - d.scroll.top
 
 		// If our cursor is within the list, we draw a cursor next to it
-		if int(idx) < len(s.Children) {
+		if d.cursor >= d.scroll.top && int(idx) < len(s.Children) {
 			ch := s.Children[idx]
 			// Create a surface for the cursor
 			cur := vxfw.NewSurface(ctx.Max.Width, ch.Surface.Size.Height, ch.Surface.Widget)


### PR DESCRIPTION
If the list is drawn with a scroll offset while the cursor is behind the cursor offset, a integer overflow occurs.