### PR TITLE
parser: Fix overflow for 32-bit archs in CSI.Param

### DIFF
--- a/ansi/parser.go
+++ b/ansi/parser.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"math"
 	"strings"
 	"sync"
 	"time"
@@ -1161,7 +1162,11 @@ func (seq CSI) Param(i int) int {
 	if i < 0 || i >= seq.NumParameters {
 		return 0
 	}
-	return int(seq.Params()[i])
+	var ret uint32 = seq.Params()[i]
+	if uint64(ret) > uint64(math.MaxInt) {
+		return math.MaxInt
+	}
+	return int(ret)
 }
 
 func (seq CSI) ColonAfter(i int) bool {

--- a/ansi/parser_test.go
+++ b/ansi/parser_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"math"
 	"reflect"
 	"strings"
 	"testing"
@@ -458,7 +459,11 @@ func TestCSIParameterSaturatesWhenTooLong(t *testing.T) {
 	if !ok {
 		t.Fatalf("sequence = %#v, want CSI", seq)
 	}
-	if got, want := csi.Param(0), int(^uint32(0)); got != want {
+	want := uint64(^uint32(0))
+	if want > uint64(math.MaxInt) {
+		want = uint64(math.MaxInt)
+	}
+	if got := csi.Param(0); uint64(got) != want {
 		t.Fatalf("CSI param = %d, want saturated %d", got, want)
 	}
 }


### PR DESCRIPTION
The `Param()` function is returning `int(seq.Params()[i])` and this is problematic in cases when this value is uint32max. While it works without problems on 64-bit systems, since int defaults to int64, this fails on 32-bit systems. This is now fixed with returning MaxInt if the value exceeds that threshold.

In addition to this, the test `TestCSIParameterSaturatesWhenTooLong` was also directly using `int(^uint32(0))` which will also fail on 32-bit systems for similar reasons. Similar to above fix, the max values specific to arch are computed and compared.